### PR TITLE
Update ButtonMapper.svelte

### DIFF
--- a/src/lib/components/ButtonMapper.svelte
+++ b/src/lib/components/ButtonMapper.svelte
@@ -21,7 +21,7 @@
     let editValue: string = $state("");
 
     function buttonLabel(index: number): string {
-        return COMMON_BUTTONS[index+1] ?? `Button ${index}`;
+        return `Button ${index}`;
     }
 
     $effect(() => {

--- a/src/lib/components/ButtonMapper.svelte
+++ b/src/lib/components/ButtonMapper.svelte
@@ -21,7 +21,7 @@
     let editValue: string = $state("");
 
     function buttonLabel(index: number): string {
-        return COMMON_BUTTONS[index] ?? `Button ${index}`;
+        return COMMON_BUTTONS[index+1] ?? `Button ${index}`;
     }
 
     $effect(() => {


### PR DESCRIPTION
Fix #5 

At least on my device, I do not know if is was a common general bug or it's related to my device specifically.

Bacause the button list here:
https://github.com/niltonperimneto/twister/blob/e9c7a3a2efa86f16a75b28ea42628c0c0b41b124/src/lib/types.ts#L111

starts at index 1.

I do not know if it's better my little fix or change the indexing in the COMMON_BUTTONS list. That's up to you to decide.