### PR TITLE
Enable custom-protocol feature for Tauri

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ name = "twister"
 path = "src/main.rs"
 
 [dependencies]
-tauri = { version = "2.10", features = [] }
+tauri = { version = "2.10", features = ["custom-protocol"] }
 tauri-plugin-shell = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
- Enable `custom-protocol` Tauri feature in `Cargo.toml`
- Required for Flatpak builds where assets must be served via Tauri's custom protocol instead of a localhost dev server

This was supposed to be part of #21 but was lost during the merge.