### PR TITLE
Add keyboard configuration via clackd (VIA-style layouts)

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -18,8 +18,18 @@ jobs:
 
     steps:
       - name: Install system dependencies
+        # --disablerepo='*openh264*': the fedora-cisco-openh264 repo is served
+        #   from a single Cisco host with no mirrors and regularly times out,
+        #   killing the whole job ("All mirrors were tried"). Nothing we need
+        #   lives there — openh264 only comes in as a weak dependency.
+        # install_weak_deps=False: skip recommended packages (multimedia
+        #   codecs, pipewire, …) that a headless build container never uses.
+        # retries=5: ride out transient mirror hiccups instead of failing.
         run: |
           dnf install -y \
+            --disablerepo='*openh264*' \
+            --setopt=install_weak_deps=False \
+            --setopt=retries=5 \
             webkit2gtk4.1-devel \
             gtk3-devel \
             libsoup3-devel \
@@ -45,7 +55,7 @@ jobs:
 
       - name: Setup Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          curl --proto '=https' --tlsv1.2 -sSf --retry 5 --retry-delay 2 https://sh.rustup.rs | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Bun
@@ -73,7 +83,7 @@ jobs:
 
       - name: Install Tauri CLI
         run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          curl -L --proto '=https' --tlsv1.2 -sSf --retry 5 --retry-delay 2 https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall tauri-cli --version "^2" --no-confirm
 
       - name: Verify tag matches Cargo.toml (drift guard)
@@ -109,23 +119,22 @@ jobs:
             VERSION=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' src-tauri/tauri.conf.json | head -1)
           fi
 
-          # Build AppDir with just the binary (no bundled libs - use system libs)
-          mkdir -p AppDir/usr/bin
-          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
-          cp src-tauri/target/release/$BINARY AppDir/usr/bin/
-          cp src-tauri/icons/128x128@2x.png AppDir/usr/share/icons/hicolor/256x256/apps/${BINARY}.png
-          cp src-tauri/icons/128x128@2x.png AppDir/${BINARY}.png
+          # Build AppDir with just the binary (no bundled libs - use system libs).
+          # Mirrors scripts/build-appimage.sh so local and CI artifacts match.
+          install -Dm755 src-tauri/target/release/$BINARY AppDir/usr/bin/$BINARY
+          install -Dm644 src-tauri/icons/128x128@2x.png \
+            AppDir/usr/share/icons/hicolor/256x256/apps/${BINARY}.png
+          install -Dm644 src-tauri/icons/128x128@2x.png AppDir/${BINARY}.png
 
-          # Create desktop file
-          cat > AppDir/${BINARY}.desktop <<'DESKTOP'
-          [Desktop Entry]
-          Name=Twister
-          Exec=twister
-          Icon=twister
-          Type=Application
-          Categories=Utility;
-          DESKTOP
-          sed -i 's/^          //' AppDir/${BINARY}.desktop
+          # Desktop entry: canonical .desktop with the Icon field rewritten to
+          # "twister" to match the AppDir's top-level twister.png.
+          install -Dm644 io.github.niltonperimneto.Twister.desktop \
+            AppDir/${BINARY}.desktop
+          sed -i 's|^Icon=.*|Icon=twister|' AppDir/${BINARY}.desktop
+
+          # AppStream metainfo — lets appimaged / GNOME Software identify the bundle.
+          install -Dm644 io.github.niltonperimneto.Twister.metainfo.xml \
+            AppDir/usr/share/metainfo/io.github.niltonperimneto.Twister.metainfo.xml
 
           # Create AppRun
           cat > AppDir/AppRun <<'APPRUN'
@@ -137,8 +146,9 @@ jobs:
           sed -i 's/^          //' AppDir/AppRun
           chmod +x AppDir/AppRun
 
-          # Download appimagetool and package
-          curl -Lo appimagetool https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
+          # Download appimagetool and package (retry transient network failures)
+          curl -fL --retry 5 --retry-delay 2 --retry-all-errors -o appimagetool \
+            https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
           chmod +x appimagetool
           ARCH=x86_64 ./appimagetool AppDir "${OUTDIR}/${APP}_${VERSION}_amd64.AppImage"
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@tauri-apps/api": "~2.11.1",
-    "@tauri-apps/cli": "~2.11.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@the-via/reader": "^1.13.0"
@@ -22,17 +21,14 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.4",
     "@tailwindcss/vite": "^4.3.2",
+    "@tauri-apps/cli": "~2.11.4",
     "@types/node": "^26.1.0",
     "daisyui": "^5.6.14",
-    "esbuild": "^0.28.1",
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.1",
     "tailwindcss": "^4.3",
     "typescript": "^6.0.3",
     "vite": "^8.1.3",
     "vitest": "^4.1.10"
-  },
-  "allowScripts": {
-    "esbuild@0.28.1": true
   }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,8 @@ tauri-plugin-shell = "2.3"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 serde = { version = "1.0", features = ["derive"] }
+# Not imported by our code, but tauri::generate_context! expands to
+# `::serde_json` paths in this crate — removing it breaks the build.
 serde_json = "1.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "sync", "time", "macros"] }
 zbus = { version = "5.16", default-features = false, features = ["tokio"] }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
     import { themeStore } from "$lib/stores/theme.svelte";
     import { updaterStore } from "$lib/stores/updater.svelte";
     import { getToasts, addToast } from "$lib/stores/toast.svelte";
+    import { DUR, duration, easeOut } from "$lib/motion";
     import type { View } from "$lib/types";
     import Titlebar from "$lib/components/Titlebar.svelte";
     import Sidebar from "$lib/components/Sidebar.svelte";
@@ -229,8 +230,13 @@
             {#key currentView}
                 <div
                     class="absolute inset-0 flex flex-col"
-                    in:fly={{ y: 8, duration: 200, delay: 80 }}
-                    out:fade={{ duration: 120 }}
+                    in:fly={{
+                        y: 8,
+                        duration: duration(DUR.base),
+                        delay: duration(80),
+                        easing: easeOut,
+                    }}
+                    out:fade={{ duration: duration(DUR.fast) }}
                 >
                     {#if currentView === "welcome"}
                         <WelcomePage onNavigate={handleNavigate} />
@@ -403,10 +409,17 @@
                                                 <div
                                                     in:fly={{
                                                         y: 12,
-                                                        duration: 250,
-                                                        delay: 60,
+                                                        duration: duration(
+                                                            DUR.base,
+                                                        ),
+                                                        delay: duration(60),
+                                                        easing: easeOut,
                                                     }}
-                                                    out:fade={{ duration: 100 }}
+                                                    out:fade={{
+                                                        duration: duration(
+                                                            DUR.fast,
+                                                        ),
+                                                    }}
                                                 >
                                                     {#if activeTab === "dpi"}
                                                         <DpiEditor
@@ -525,7 +538,7 @@
         >
             {#each getToasts() as toast (toast.id)}
                 <div
-                    transition:fade={{ duration: 150 }}
+                    transition:fade={{ duration: duration(DUR.fast) }}
                     class="alert {toast.kind === 'error'
                         ? 'alert-error'
                         : 'alert-info'} text-xs py-2 px-3 shadow-lg"

--- a/src/lib/components/AboutPage.svelte
+++ b/src/lib/components/AboutPage.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
     import { onMount } from "svelte";
     import { fade } from "svelte/transition";
+    import { DUR, duration } from "$lib/motion";
     import { getVersion } from "@tauri-apps/api/app";
     import auraLogo from "$lib/assets/aura-logo.svg";
     import { openUrl } from "$lib/ipc/commands";
@@ -42,7 +43,7 @@
 
 <div
     class="flex-1 flex justify-center p-8 overflow-y-auto"
-    in:fade={{ duration: 250 }}
+    in:fade={{ duration: duration(DUR.base) }}
     out:fade={{ duration: 150 }}
 >
     <div class="max-w-md w-full flex flex-col items-center gap-6 my-auto">

--- a/src/lib/components/DonatePage.svelte
+++ b/src/lib/components/DonatePage.svelte
@@ -1,12 +1,13 @@
 <!-- DonatePage — support the project, repos, and donation links -->
 <script lang="ts">
     import { fade } from "svelte/transition";
+    import { DUR, duration } from "$lib/motion";
     import { openUrl } from "$lib/ipc/commands";
 </script>
 
 <div
     class="flex-1 flex justify-center p-8 overflow-y-auto"
-    in:fade={{ duration: 250 }}
+    in:fade={{ duration: duration(DUR.base) }}
     out:fade={{ duration: 150 }}
 >
     <div

--- a/src/lib/components/DpiEditor.svelte
+++ b/src/lib/components/DpiEditor.svelte
@@ -103,7 +103,7 @@
   <div class="editor-card">
     <div class="editor-card-header">
       <h3 class="text-sm font-medium flex items-center gap-2">
-        <svg class="w-3.5 h-3.5 opacity-60 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        <svg class="w-3.5 h-3.5 opacity-60 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
         Polling Rate
       </h3>
       <span class="text-xs font-mono text-primary font-bold">{localReportRate} Hz</span>
@@ -129,7 +129,10 @@
   {#each profile.resolutions as res, i (res.index)}
     {@const dpi = localDpis[i] ?? res.dpi_x}
     {@const isClickable = !res.is_active && !res.is_disabled}
-    <div 
+    <!-- Card-wide click is a pointer convenience; the radio inside is the
+         accessible (keyboard/screen-reader) control for the same action. -->
+    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+    <div
       onclick={(e) => {
         const target = e.target as HTMLElement;
         if (target.closest('input[type="range"]')) return;
@@ -139,11 +142,12 @@
     >
       <div class="editor-card-header">
         <div class="flex items-center gap-3">
-          <input 
-            type="radio" 
-            name="active_dpi_stage" 
-            checked={res.is_active} 
+          <input
+            type="radio"
+            name="active_dpi_stage"
+            checked={res.is_active}
             disabled={res.is_disabled}
+            aria-label="Use stage {res.index} as the active DPI"
             class="radio radio-primary radio-xs cursor-pointer disabled:opacity-30"
             onclick={(e) => {
               e.stopPropagation();
@@ -163,6 +167,7 @@
       </div>
 
       {#if res.dpi_list.length > 0}
+        <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
         <div class="flex flex-col gap-1.5" onclick={(e) => e.stopPropagation()}>
           <input
             type="range"
@@ -171,9 +176,11 @@
             max={Math.max(...res.dpi_list)}
             step={dpiStep(res.dpi_list)}
             value={dpi}
+            aria-label="Stage {res.index} DPI"
+            aria-valuetext="{dpi} DPI"
             oninput={(e) => debouncedDpiWrite(res, i, Number(e.currentTarget.value))}
           />
-          <div class="flex justify-between px-0.5">
+          <div class="flex justify-between px-0.5" aria-hidden="true">
             <span class="text-[9px] font-mono text-base-content/30">{Math.min(...res.dpi_list)}</span>
             <span class="text-[9px] font-mono text-base-content/30">{Math.max(...res.dpi_list)}</span>
           </div>

--- a/src/lib/components/KeyboardLighting.svelte
+++ b/src/lib/components/KeyboardLighting.svelte
@@ -81,17 +81,38 @@
         }
     });
 
-    function handleModeChange(e: Event) {
+    /* Sliders update local state instantly for a live UI, but the HID
+       write is debounced — same 150ms rhythm the mouse editors use — so a
+       drag doesn't flood the keyboard with reports. */
+    function makeDebounce<T extends unknown[]>(
+        fn: (...a: T) => void,
+        ms: number,
+    ) {
+        let t: ReturnType<typeof setTimeout> | null = null;
+        return (...a: T) => {
+            if (t) clearTimeout(t);
+            t = setTimeout(() => fn(...a), ms);
+        };
+    }
+
+    function writeLighting(mutate: (data: number[]) => void) {
         if (!kb.lighting) return;
-        const select = e.target as HTMLSelectElement;
-        const newMode = parseInt(select.value, 10);
         const data = [...kb.lighting];
-        data[0] = newMode;
+        mutate(data);
         kb.updateLighting(data);
     }
 
+    const debouncedWrite = makeDebounce(writeLighting, 150);
+
+    function handleModeChange(e: Event) {
+        const select = e.target as HTMLSelectElement;
+        const newMode = parseInt(select.value, 10);
+        writeLighting((data) => {
+            data[0] = newMode;
+        });
+    }
+
     function handleColorChange(e: Event) {
-        if (!kb.lighting) return;
         const input = e.target as HTMLInputElement;
         const hex = input.value;
         const r = parseInt(hex.slice(1, 3), 16);
@@ -100,34 +121,27 @@
         localR = r;
         localG = g;
         localB = b;
-        
-        const data = [...kb.lighting];
-        data[1] = r;
-        data[2] = g;
-        data[3] = b;
-        kb.updateLighting(data);
+        debouncedWrite((data) => {
+            data[1] = r;
+            data[2] = g;
+            data[3] = b;
+        });
     }
 
     function handleBrightnessChange(e: Event) {
-        if (!kb.lighting) return;
-        const input = e.target as HTMLInputElement;
-        const val = parseInt(input.value, 10);
+        const val = parseInt((e.target as HTMLInputElement).value, 10);
         localBrightness = val;
-        
-        const data = [...kb.lighting];
-        data[4] = val;
-        kb.updateLighting(data);
+        debouncedWrite((data) => {
+            data[4] = val;
+        });
     }
 
     function handleSpeedChange(e: Event) {
-        if (!kb.lighting) return;
-        const input = e.target as HTMLInputElement;
-        const val = parseInt(input.value, 10);
+        const val = parseInt((e.target as HTMLInputElement).value, 10);
         localSpeed = val;
-        
-        const data = [...kb.lighting];
-        data[6] = val;
-        kb.updateLighting(data);
+        debouncedWrite((data) => {
+            data[6] = val;
+        });
     }
 
     // Helper to format rgb to hex for color input
@@ -155,13 +169,13 @@
     {:else if kb.lighting}
         <!-- Effect Mode -->
         <div class="form-control">
-            <label class="label">
+            <label class="label" for="kb-lighting-effect">
                 <span class="label-text font-semibold flex items-center gap-2">
                     <Icon name="wand-2" class="w-4 h-4 opacity-70" />
                     Effect
                 </span>
             </label>
-            <select class="select select-bordered select-sm w-full" value={mode} onchange={handleModeChange}>
+            <select id="kb-lighting-effect" class="select select-bordered select-sm w-full" value={mode} onchange={handleModeChange}>
                 {#each effects as effect}
                     <option value={effect.id}>{effect.name}</option>
                 {/each}
@@ -170,7 +184,7 @@
 
         <!-- Color -->
         <div class="form-control">
-            <label class="label">
+            <label class="label" for="kb-lighting-color">
                 <span class="label-text font-semibold flex items-center gap-2">
                     <Icon name="palette" class="w-4 h-4 opacity-70" />
                     Color
@@ -178,10 +192,11 @@
             </label>
             <div class="flex gap-3 items-center">
                 <input
+                    id="kb-lighting-color"
                     type="color"
                     class="w-10 h-10 p-0 border-0 rounded-md cursor-pointer bg-transparent"
                     value={rgbToHex(localR, localG, localB)}
-                    onchange={handleColorChange}
+                    oninput={handleColorChange}
                     disabled={colorDisabled}
                 />
                 <span class="text-sm opacity-60">
@@ -198,7 +213,7 @@
 
         <!-- Brightness -->
         <div class="form-control">
-            <label class="label">
+            <label class="label" for="kb-lighting-brightness">
                 <span class="label-text font-semibold flex items-center gap-2">
                     <Icon name="sun" class="w-4 h-4 opacity-70" />
                     Brightness
@@ -206,15 +221,17 @@
                 <span class="text-xs opacity-50">{localBrightness} / 15</span>
             </label>
             <input
+                id="kb-lighting-brightness"
                 type="range"
                 min="0"
                 max="15"
                 class="slider"
                 value={localBrightness}
-                onchange={handleBrightnessChange}
+                aria-valuetext="{localBrightness} of 15"
+                oninput={handleBrightnessChange}
                 disabled={brightnessDisabled}
             />
-            <div class="w-full flex justify-between text-xs px-1 pt-1 opacity-40">
+            <div class="w-full flex justify-between text-xs px-1 pt-1 opacity-40" aria-hidden="true">
                 <span>Off</span>
                 <span>Max</span>
             </div>
@@ -222,7 +239,7 @@
 
         <!-- Speed -->
         <div class="form-control">
-            <label class="label">
+            <label class="label" for="kb-lighting-speed">
                 <span class="label-text font-semibold flex items-center gap-2">
                     <Icon name="gauge" class="w-4 h-4 opacity-70" />
                     Speed
@@ -230,15 +247,17 @@
                 <span class="text-xs opacity-50">{localSpeed} / 15</span>
             </label>
             <input
+                id="kb-lighting-speed"
                 type="range"
                 min="0"
                 max="15"
                 class="slider"
                 value={localSpeed}
-                onchange={handleSpeedChange}
+                aria-valuetext="{localSpeed} of 15"
+                oninput={handleSpeedChange}
                 disabled={speedDisabled}
             />
-            <div class="w-full flex justify-between text-xs px-1 pt-1 opacity-40">
+            <div class="w-full flex justify-between text-xs px-1 pt-1 opacity-40" aria-hidden="true">
                 <span>Slow</span>
                 <span>Fast</span>
             </div>

--- a/src/lib/components/KeycodePicker.svelte
+++ b/src/lib/components/KeycodePicker.svelte
@@ -136,7 +136,7 @@
         overflow: hidden;
         cursor: pointer;
         box-shadow: inset 0 1px 0 0 oklch(1 0 0 / 0.05);
-        transition: all 200ms cubic-bezier(0.16, 1, 0.3, 1);
+        transition: all var(--dur-fast) var(--ease-out);
     }
     .kc-btn:hover {
         border-color: oklch(0.74 0.16 248 / 0.35);

--- a/src/lib/components/LedEditor.svelte
+++ b/src/lib/components/LedEditor.svelte
@@ -265,10 +265,16 @@
         {@const hex = rgbToHex(led.color)}
 
         <div class="led-zone {isOpen ? 'led-zone-open' : ''}">
-            <button onclick={() => toggleZone(led.index)} class="led-zone-header">
+            <button
+                onclick={() => toggleZone(led.index)}
+                class="led-zone-header"
+                aria-expanded={isOpen}
+                aria-label="LED {led.index} settings, current mode {LED_MODES[led.mode] ?? `Mode ${led.mode}`}"
+            >
                 <div class="flex items-center gap-2.5">
                     <div
                         class="w-3.5 h-3.5 rounded-full shrink-0"
+                        aria-hidden="true"
                         style="background: {hex}; box-shadow: 0 0 8px {hex}55, inset 0 1px 0 rgba(255,255,255,.15);"
                     ></div>
                     <span class="text-sm font-medium">LED {led.index}</span>
@@ -280,6 +286,7 @@
                     class="w-3.5 h-3.5 opacity-40 transition-transform duration-200 {isOpen ? 'rotate-180' : ''}"
                     viewBox="0 0 24 24" fill="none" stroke="currentColor"
                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                    aria-hidden="true"
                 ><polyline points="6 9 12 15 18 9" /></svg>
             </button>
 
@@ -316,6 +323,7 @@
                                 <div class="flex items-center gap-3">
                                     <div
                                         class="w-14 h-14 rounded-lg shrink-0 ring-1 ring-white/10 transition-[background] duration-150"
+                                        aria-hidden="true"
                                         style="background: {hex}; box-shadow: 0 0 18px {hex}40, inset 0 1px 0 rgba(255,255,255,.12);"
                                     ></div>
                                     <div class="flex-1 flex flex-col gap-1 min-w-0">
@@ -330,6 +338,7 @@
                                                 type="text"
                                                 maxlength="6"
                                                 spellcheck="false"
+                                                aria-label="Hex color code"
                                                 value={hexInput.replace("#", "")}
                                                 oninput={(e) => applyHex(e.currentTarget.value)}
                                                 class="join-item input input-sm font-mono uppercase text-xs flex-1 tracking-widest"
@@ -348,6 +357,8 @@
                                         <input
                                             type="range" min="0" max="360" step="1"
                                             value={h}
+                                            aria-label="Hue"
+                                            aria-valuetext="{h} degrees"
                                             oninput={(e) => applyHsl(Number(e.currentTarget.value), s, l)}
                                             class="slider slider-swatch hsl-h"
                                         />
@@ -358,6 +369,8 @@
                                         <input
                                             type="range" min="0" max="100" step="1"
                                             value={s}
+                                            aria-label="Saturation"
+                                            aria-valuetext="{s}%"
                                             oninput={(e) => applyHsl(h, Number(e.currentTarget.value), l)}
                                             class="slider slider-swatch hsl-s"
                                         />
@@ -368,6 +381,8 @@
                                         <input
                                             type="range" min="0" max="100" step="1"
                                             value={l}
+                                            aria-label="Lightness"
+                                            aria-valuetext="{l}%"
                                             oninput={(e) => applyHsl(h, s, Number(e.currentTarget.value))}
                                             class="slider slider-swatch hsl-l"
                                         />
@@ -442,6 +457,8 @@
                             <input
                                 type="range" min="0" max="255" step="1"
                                 value={led.brightness}
+                                aria-label="Brightness"
+                                aria-valuetext="{Math.round((led.brightness / 255) * 100)}%"
                                 oninput={(e) => applyBrightness(led, Number(e.currentTarget.value))}
                                 class="slider"
                             />
@@ -459,6 +476,8 @@
                                 <input
                                     type="range" min="0" max="10000" step="100"
                                     value={led.effect_duration}
+                                    aria-label="Effect duration"
+                                    aria-valuetext="{led.effect_duration} milliseconds"
                                     oninput={(e) => applyDuration(led, Number(e.currentTarget.value))}
                                     class="slider"
                                 />
@@ -524,7 +543,7 @@
         box-shadow:
             0 1px 3px rgba(0, 0, 0, 0.4),
             inset 0 1px 0 rgba(255, 255, 255, 0.12);
-        transition: transform 100ms ease, box-shadow 100ms ease;
+        transition: transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) ease;
         cursor: pointer;
     }
     .preset-swatch:hover {

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -37,7 +37,7 @@
 
 <aside
     class="{collapsed ? 'w-14' : 'w-56'} shrink-0 flex flex-col gap-3 py-3 overflow-y-auto overflow-x-hidden"
-    style="border-right: 1px solid oklch(1 0 0 / 0.06); scrollbar-width: none; transition: width 200ms cubic-bezier(0.16, 1, 0.3, 1);"
+    style="border-right: 1px solid oklch(1 0 0 / 0.06); scrollbar-width: none; transition: width var(--dur-fast) var(--ease-out);"
 >
     <!-- Devices nav — the way back to the editor from Support/About,
          even when nothing is connected -->

--- a/src/lib/components/StatusOverlay.svelte
+++ b/src/lib/components/StatusOverlay.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
     import type { DaemonStatus } from "$lib/types";
     import { fade } from "svelte/transition";
+    import { DUR, duration } from "$lib/motion";
 
     interface Props {
         status: DaemonStatus;
@@ -19,7 +20,7 @@
 
 {#if status.status === "disconnected" || error}
     <div
-        transition:fade={{ duration: 150 }}
+        transition:fade={{ duration: duration(DUR.fast) }}
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-xl"
     >
         <div class="editor-card max-w-xs w-full mx-4 text-center p-6! gap-4!">

--- a/src/lib/components/WelcomePage.svelte
+++ b/src/lib/components/WelcomePage.svelte
@@ -1,9 +1,13 @@
-<!-- WelcomePage — aesthetic startup splash screen -->
+<!-- WelcomePage — aesthetic startup splash screen.
+     Skippable (click, Enter/Space/Escape), announces itself as a status to
+     screen readers, and collapses to an instant hand-off when the user
+     prefers reduced motion. -->
 <script lang="ts">
     import { onMount } from "svelte";
     import { fade, fly } from "svelte/transition";
     import type { View } from "../types";
     import { deviceStore } from "$lib/stores/device.svelte";
+    import { DUR, duration, easeOut, prefersReducedMotion } from "$lib/motion";
     import auraLogo from "$lib/assets/aura-logo.svg";
 
     interface Props {
@@ -12,30 +16,69 @@
 
     let { onNavigate }: Props = $props();
 
-    onMount(() => {
-        // Fast 1100ms play window before checking hardware status to keep the app feeling snappy
-        const finalTimer = setTimeout(() => {
-            const checkAndNavigate = () => {
-                if (!deviceStore.loading) {
-                    onNavigate("devices");
-                } else {
-                    setTimeout(checkAndNavigate, 50);
-                }
-            };
-            checkAndNavigate();
-        }, 1100);
+    /* With reduced motion there is nothing to watch — hand off almost
+       immediately instead of holding an effectively static frame. */
+    const SPLASH_MS = prefersReducedMotion() ? 300 : 1100;
 
-        return () => clearTimeout(finalTimer);
+    let navigated = false;
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function finish() {
+        if (navigated) return;
+        navigated = true;
+        if (pollTimer) clearTimeout(pollTimer);
+        onNavigate("devices");
+    }
+
+    /* Wait for the device store before navigating so the editor doesn't
+       flash an empty state, but never against the user's will: an explicit
+       skip (click/key) navigates straight away. */
+    function finishWhenReady() {
+        if (navigated) return;
+        if (!deviceStore.loading) {
+            finish();
+        } else {
+            pollTimer = setTimeout(finishWhenReady, 50);
+        }
+    }
+
+    function skip(e?: KeyboardEvent) {
+        if (e && e.key !== "Enter" && e.key !== " " && e.key !== "Escape") {
+            return;
+        }
+        e?.preventDefault();
+        finish();
+    }
+
+    onMount(() => {
+        const timer = setTimeout(finishWhenReady, SPLASH_MS);
+        return () => {
+            clearTimeout(timer);
+            if (pollTimer) clearTimeout(pollTimer);
+        };
     });
 </script>
 
+<svelte:window onkeydown={skip} />
+
+<!-- The whole splash is one click target: any interaction skips ahead.
+     Keyboard users get the same escape via the window keydown handler above
+     and the visible "skip" button below, so the div's click handler is a
+     pointer-only convenience. -->
+<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
 <div
-    class="relative flex-1 flex flex-col items-center justify-center overflow-hidden p-8 min-h-full select-none"
-    in:fade={{ duration: 400 }}
-    out:fade={{ duration: 300 }}
+    class="relative flex-1 flex flex-col items-center justify-center overflow-hidden p-8 min-h-full select-none cursor-pointer"
+    role="status"
+    aria-label="Twister is starting"
+    onclick={() => finish()}
+    in:fade={{ duration: duration(DUR.slow), easing: easeOut }}
+    out:fade={{ duration: duration(DUR.base), easing: easeOut }}
 >
     <!-- Liquid-like dynamic floating orbs in the background -->
-    <div class="absolute inset-0 z-0 pointer-events-none overflow-hidden">
+    <div
+        class="absolute inset-0 z-0 pointer-events-none overflow-hidden"
+        aria-hidden="true"
+    >
         <div
             class="absolute left-1/4 top-1/4 w-[450px] h-[450px] rounded-full bg-primary/10 blur-[130px] animate-orb-drift origin-center"
         ></div>
@@ -44,70 +87,133 @@
         ></div>
     </div>
 
-    <!-- Minimalist Glassmorphic Presentation -->
-    <div 
+    <!-- Minimalist glassmorphic card -->
+    <div
         class="relative z-10 flex flex-col items-center max-w-sm w-full p-10 rounded-3xl border border-white/5 bg-white/[0.015] backdrop-blur-2xl text-center"
         style="box-shadow: 0 30px 70px -20px rgba(0, 0, 0, 0.45), inset 0 1px 0 0 rgba(255, 255, 255, 0.05), 0 0 50px -10px oklch(0.74 0.16 248 / 0.05);"
-        in:fly={{ y: 15, duration: 900 }}
+        in:fly={{ y: 15, duration: duration(2 * DUR.slow), easing: easeOut }}
     >
-        <!-- Floating Logo in a soft glowing orb -->
-        <div class="relative w-28 h-28 flex items-center justify-center mb-8">
-            <div class="absolute inset-0 rounded-full bg-primary/5 blur-md animate-pulse"></div>
-            <div class="absolute inset-2 rounded-full border border-white/5 animate-pulse"></div>
+        <!-- Floating logo in a soft glowing orb -->
+        <div
+            class="relative w-28 h-28 flex items-center justify-center mb-8"
+            aria-hidden="true"
+        >
+            <div
+                class="absolute inset-0 rounded-full bg-primary/5 blur-md animate-pulse"
+            ></div>
+            <div
+                class="absolute inset-2 rounded-full border border-white/5 animate-pulse"
+            ></div>
             <img
                 src={auraLogo}
-                alt="Twister logo"
+                alt=""
                 class="w-16 h-16 relative drop-shadow-[0_0_12px_rgba(114,137,218,0.2)] animate-logo-float"
             />
         </div>
 
         <!-- Sleek branding with wide letter-spacing -->
         <div class="flex flex-col items-center gap-3">
-            <h1 
+            <h1
                 class="text-2xl font-light tracking-[0.4em] bg-gradient-to-r from-base-content via-base-content/90 to-base-content/50 bg-clip-text text-transparent"
                 style="font-family: var(--font-display); text-shadow: 0 0 30px rgba(255,255,255,0.05);"
-                in:fly={{ y: 10, duration: 800, delay: 150 }}
+                in:fly={{
+                    y: 10,
+                    duration: duration(2 * DUR.slow),
+                    delay: duration(DUR.fast),
+                    easing: easeOut,
+                }}
             >
                 TWISTER
             </h1>
-            
-            <div 
+
+            <div
                 class="w-8 h-[1px] bg-linear-to-r from-primary to-secondary opacity-60 my-1"
-                in:fade={{ duration: 600, delay: 300 }}
+                aria-hidden="true"
+                in:fade={{
+                    duration: duration(DUR.slow),
+                    delay: duration(2 * DUR.fast),
+                }}
             ></div>
 
-            <p 
+            <p
                 class="text-xs text-base-content/50 font-normal leading-relaxed tracking-wide max-w-[280px]"
-                in:fly={{ y: 10, duration: 800, delay: 400 }}
+                in:fly={{
+                    y: 10,
+                    duration: duration(2 * DUR.slow),
+                    delay: duration(DUR.base + DUR.fast),
+                    easing: easeOut,
+                }}
             >
                 Precision control. Refined design.
             </p>
         </div>
 
         <!-- Subtle breathing pulse loader -->
-        <div 
+        <div
             class="flex items-center gap-1.5 mt-8 opacity-45"
-            in:fade={{ duration: 600, delay: 500 }}
+            in:fade={{
+                duration: duration(DUR.slow),
+                delay: duration(2 * DUR.base),
+            }}
         >
-            <span class="w-1.5 h-1.5 rounded-full bg-primary animate-ping"></span>
-            <span class="text-[8px] font-mono tracking-[0.2em] text-base-content/40 uppercase">Loading</span>
+            <span
+                class="w-1.5 h-1.5 rounded-full bg-primary animate-ping"
+                aria-hidden="true"
+            ></span>
+            <span
+                class="text-[8px] font-mono tracking-[0.2em] text-base-content/40 uppercase"
+                >Loading</span
+            >
         </div>
     </div>
+
+    <!-- Accessible skip control; also documents the click-to-skip gesture -->
+    <button
+        type="button"
+        class="skip-hint relative z-10 mt-6 text-[10px] tracking-[0.15em] uppercase text-base-content/25 bg-transparent border-none cursor-pointer"
+        onclick={(e) => {
+            e.stopPropagation();
+            finish();
+        }}
+        in:fade={{
+            duration: duration(DUR.slow),
+            delay: duration(3 * DUR.base),
+        }}
+    >
+        Click anywhere to skip
+    </button>
 </div>
 
 <style>
+    /* Splash-only ambient motion, on the shared easing/duration language.
+       All three are decorative and disabled by the global
+       prefers-reduced-motion block in app.css. */
     @keyframes orb-drift {
-        0% { transform: translate(0px, 0px) scale(1); }
-        50% { transform: translate(25px, -25px) scale(1.05); }
-        100% { transform: translate(0px, 0px) scale(1); }
+        0%,
+        100% {
+            transform: translate(0, 0) scale(1);
+        }
+        50% {
+            transform: translate(25px, -25px) scale(1.05);
+        }
     }
     @keyframes orb-float {
-        0%, 100% { transform: translate(0px, 0px) scale(1); }
-        50% { transform: translate(-25px, 25px) scale(1.03); }
+        0%,
+        100% {
+            transform: translate(0, 0) scale(1);
+        }
+        50% {
+            transform: translate(-25px, 25px) scale(1.03);
+        }
     }
     @keyframes logo-float {
-        0%, 100% { transform: translateY(0px) scale(1); }
-        50% { transform: translateY(-4px) scale(1.02); }
+        0%,
+        100% {
+            transform: translateY(0) scale(1);
+        }
+        50% {
+            transform: translateY(-4px) scale(1.02);
+        }
     }
     .animate-orb-drift {
         animation: orb-drift 15s ease-in-out infinite;
@@ -118,7 +224,12 @@
     .animate-logo-float {
         animation: logo-float 4s ease-in-out infinite;
     }
+
+    .skip-hint {
+        transition: color var(--dur-fast) ease;
+    }
+    .skip-hint:hover,
+    .skip-hint:focus-visible {
+        color: oklch(0.92 0 0 / 0.6);
+    }
 </style>
-
-
-

--- a/src/lib/keyboard/definitions.ts
+++ b/src/lib/keyboard/definitions.ts
@@ -29,8 +29,6 @@ export type ViaDefinition =
   | ReturnType<typeof keyboardDefinitionV2ToVIADefinitionV2>
   | ReturnType<typeof keyboardDefinitionV3ToVIADefinitionV3>;
 
-export type ViaKey = ViaDefinition['layouts']['keys'][number];
-
 /* Raw definition JSON bundled from ./definitions/*.json. */
 const rawModules = import.meta.glob('./definitions/*.json', { eager: true }) as Record<
   string,

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,38 @@
+/* Shared motion vocabulary for Svelte transitions.
+ *
+ * CSS animations/transitions inherit the app-wide tokens in app.css
+ * (--ease-out, --dur-*) and are neutralised by the global
+ * prefers-reduced-motion block there. Svelte transitions animate via
+ * inline styles, so that CSS override never reaches them — every
+ * `fly`/`fade` duration must come through `duration()` instead, which
+ * collapses to 0 when the user asks for reduced motion.
+ */
+import { expoOut } from "svelte/easing";
+
+/* Matches --ease-out: cubic-bezier(0.16, 1, 0.3, 1) in app.css. */
+export const easeOut = expoOut;
+
+/* Duration scale, in ms — mirrors --dur-* in app.css. */
+export const DUR = {
+    /* micro-interactions: toasts, tab content swaps out */
+    fast: 150,
+    /* standard: view changes, panel entrances */
+    base: 250,
+    /* emphasis: page-level fades, splash choreography */
+    slow: 400,
+} as const;
+
+const reduceMotionQuery = "(prefers-reduced-motion: reduce)";
+
+export function prefersReducedMotion(): boolean {
+    return (
+        typeof window !== "undefined" &&
+        window.matchMedia(reduceMotionQuery).matches
+    );
+}
+
+/* Duration for a Svelte transition: the requested length, or 0 when the
+ * user prefers reduced motion (element still appears, just instantly). */
+export function duration(ms: number): number {
+    return prefersReducedMotion() ? 0 : ms;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,11 +47,6 @@ export interface KeyboardDeviceDto {
   keymap: number[][];
 }
 
-/* Discriminated union for the unified sidebar device list (mice + keyboards). */
-export type UnifiedDevice =
-  | ({ kind: 'mouse' } & DeviceSummary)
-  | ({ kind: 'keyboard' } & KeyboardSummary);
-
 export interface DeviceDto {
   path: string;
   name: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,10 @@ export default defineConfig({
   build: {
     outDir: 'build',
     target: ['es2021', 'chrome100', 'safari15'],
-    minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
+    /* Rolldown-based Vite minifies with its built-in oxc minifier; the
+       previous explicit 'esbuild' setting forced esbuild as an extra
+       devDependency for the same result. */
+    minify: !process.env.TAURI_DEBUG,
     sourcemap: !!process.env.TAURI_DEBUG,
   },
 });


### PR DESCRIPTION
Twister now configures keyboards through the clackd daemon alongside the
existing ratbagd mouse support. The two daemons stay separate in the
backend (clackd speaks flat session-bus methods keyed by device id; ratbagd
uses an object-path Properties tree) and unify only in the device sidebar.

Backend (additive, mouse code untouched):
- clackd_client.rs: zbus proxy for io.github.clackd.Device with lazy
  per-layer keymap reads (pipelined GetKeycode) and optional
  GetDeviceIdentity (older daemons degrade gracefully).
- KeyboardState + clackd commands, keyboard DTOs, and a debounced
  clack:resync signal watcher. A missing clackd is non-fatal.

Frontend:
- keyboard store (lazy layers, optimistic + per-slot debounced writes to
  spare EEPROM, commit flushes pending edits).
- VIA-style physical layout: @the-via/reader parses a curated subset of
  the-via/keyboards definitions, matched by VID/PID; falls back to a raw
  rows x cols matrix grid when no definition matches.
- KeyboardEditor (layer tabs + layout + keycode picker), unified sidebar,
  and a non-blocking clackd status notice so a keyboard-only setup is not
  hidden by the ratbagd overlay.

Bundled definitions and @the-via/reader are GPL-3.0, credited in AboutPage
and definitions/NOTICE.md.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>